### PR TITLE
Include DEFAULT_DESKTOP in the 64bit Template

### DIFF
--- a/templates/WinSDK64HelloWorld.asm
+++ b/templates/WinSDK64HelloWorld.asm
@@ -39,7 +39,7 @@ WinMainCRTStartup PROC
 	mov		rcx,0			; hWnd = HWND_DESKTOP
 	lea		rdx,strMessage	; LPCSTR lpText
 	lea		r8,strTitle		; LPCSTR lpCaption
-	mov		r9d,0			; uType = MB_OK
+	mov		r9d,00020000h		; uType = MB_OK | MB_DEFAULT_DESKTOP_ONLY
 	
 	; Use the MessageBoxA API function to display the message box.
 	; To read more about MessageBox, move your mouse cursor over the


### PR DESCRIPTION
Without `MB_DEFAULT_DESKTOP_ONLY`, the message box will sometimes fail to appear. It may have to do with using multiple monitors; the message box didn't appear on either of mine. It took me hours to figure out why it wasn't appearing.

At worst, it's just a no-op.